### PR TITLE
Make local pdf link names in the org journal customizable.

### DIFF
--- a/README.org
+++ b/README.org
@@ -33,6 +33,7 @@ Download this repository, install using =M-x package-install-file= (or package-v
   (library-pdf-directory "~/Dropbox/math documents/unsorted/")
   (library-bibtex-file "~/doit/refs.bib")
   (library-download-directory "~/Downloads/")
+  (library-local-pdf-link-name "Dropbox link")
   (library-org-capture-template-key "j"))
 
 (add-to-list 'org-capture-templates

--- a/library.el
+++ b/library.el
@@ -50,6 +50,11 @@
   :type 'string
   :group 'library)
 
+(defcustom library-local-pdf-link-name "Dropbox link"
+  "Name of link to local PDF file in Org journal file."
+  :type 'string
+  :group 'library)
+
 (defcustom library-bibtex-file "~/doit/refs.bib"
   "BibTeX file where references are stored."
   :type 'string
@@ -174,7 +179,7 @@ Optionally, make use of specified ARXIV-ID."
        (format ":TITLE: %s\n" title)
        ":END:\n"
        "\n"
-       (format "[[%s][Dropbox link]]\n\n" file)
+       (format (concat "[[%s][" library-local-pdf-link-name "]]\n\n") file)
        (when arxiv-id
 	 (format "[[https://arxiv.org/abs/%s][arXiv link]]\n\n" arxiv-id))))))
 


### PR DESCRIPTION
Rationale: the user might not be a dropbox user.